### PR TITLE
fix build error introduced in previous commit

### DIFF
--- a/rtl/src/peripheral/video/tiny9990/t9990_blit.sv
+++ b/rtl/src/peripheral/video/tiny9990/t9990_blit.sv
@@ -239,7 +239,7 @@ wire srch_edge_right = work.srch.edge_left;
                          (REG.LO[2'b10] ? ( src_data_le & ~DST_DATA) : 32'b0) |
                          (REG.LO[2'b11] ? ( src_data_le &  DST_DATA) : 32'b0));
 
-    enum logic [5:0] {
+    typedef enum logic [5:0] {
         STATE_IDLE,
         STATE_STOP,
         STATE_LINE,
@@ -291,10 +291,12 @@ wire srch_edge_right = work.srch.edge_left;
         STATE_DST_WRITE_CPU_WAIT_ACK,
         STATE_DST_WRITE_WAIT,
         STATE_COMPLETE
-    } state;
-localparam STATE_DST_WRITE_P1_ODD_VRAM_WAIT_BUSY = STATE_DST_WRITE_WAIT;
-localparam STATE_DST_WRITE_VRAM_WAIT_BUSY        = STATE_DST_WRITE_WAIT;
-localparam STATE_DST_WRITE_CPU_WAIT_BUSY         = STATE_DST_WRITE_WAIT;
+    } state_t;
+localparam state_t STATE_DST_WRITE_P1_ODD_VRAM_WAIT_BUSY = STATE_DST_WRITE_WAIT;
+localparam state_t STATE_DST_WRITE_VRAM_WAIT_BUSY        = STATE_DST_WRITE_WAIT;
+localparam state_t STATE_DST_WRITE_CPU_WAIT_BUSY         = STATE_DST_WRITE_WAIT;
+
+    state_t state;
 
     reg src_nx_over;
     reg dst_nx_over;


### PR DESCRIPTION
Commit "Optimize the BLIT module of the V9990 emulator" causes the synthesis build error "ERROR (EX3652) : An enum variable may only be assigned to the same enum typed variable or one of its values" in file t9990_blit.sv in lines 1205, 1243, 1253 and 1287.

The build error happens with GOWIN FPGA Designer Version 1.9.9.03 Education Build(73833).

The proposed patch fixes the build error by explicitly defining a state_t enum type and making the localparams
STATE_DST_WRITE_P1_ODD_VRAM_WAIT_BUSY, STATE_DST_WRITE_VRAM_WAIT_BUSY and STATE_DST_WRITE_CPU_WAIT_BUSY of type state_t.

The fix has been build tested with V9990 enabled.