### PR TITLE
fix leftover from CLK_14M cleanup

### DIFF
--- a/rtl/src/peripheral/msx/bus.sv
+++ b/rtl/src/peripheral/msx/bus.sv
@@ -191,7 +191,6 @@ module EXPANSION_BUS #(
             end
 
             assign Secondary[num].CLK_21M = Primary.CLK_21M;
-            assign Secondary[num].CLK_14M = Primary.CLK_14M;
 
             assign tmp_dout    [num] = Secondary[num].DOUT     | ((num < COUNT-1) ? tmp_dout    [num + 1] : 0);
             assign tmp_busdir_n[num] = Secondary[num].BUSDIR_n & ((num < COUNT-1) ? tmp_busdir_n[num + 1] : 1);


### PR DESCRIPTION
The RTL hierarchy tab of the GOWIN FPGA Designer shows the error "ERROR EX3813 : 'CLK_14M' is not declared under prefix 'Primary'" for file rtl/src/peripheral/msx/bus.sv at line 194.

The CLK_14M signal of the BUS_IF interface was removed in previous commit "fix #7 Synchronize the operating clock with the bus clock" thus it should no longer be referenced.

Remove the unneeded assignment.

It is unclear why the assignment didn't cause other synthesis errors while building the bitstream.